### PR TITLE
Drop infinitely recursive assignment operators

### DIFF
--- a/Rehearse/src/CelBoolVar.cpp
+++ b/Rehearse/src/CelBoolVar.cpp
@@ -14,11 +14,6 @@ CelBoolVar::CelBoolVar(const char *namestr) : CelIntVar(namestr, 0.0, 1.0) {
 CelBoolVar::CelBoolVar() : CelIntVar("", 0.0, 1.0) {
 }
 
-CelBoolVar& CelBoolVar::operator= (const CelBoolVar other){
-    *this = other;
-    return *this;
-}
-
 CelBoolVar::~CelBoolVar(){
 }
 

--- a/Rehearse/src/CelBoolVar.h
+++ b/Rehearse/src/CelBoolVar.h
@@ -11,7 +11,6 @@ public:
     CelBoolVar();
     CelBoolVar(std::string &name);
     CelBoolVar(const char *namestr);
-    CelBoolVar& operator= (const CelBoolVar other);
 
     ~CelBoolVar();
 

--- a/Rehearse/src/CelExpression.cpp
+++ b/Rehearse/src/CelExpression.cpp
@@ -652,9 +652,9 @@ CelExpression & CelExpression::operator += (CelExpression &expression){
     return *this;
 }
 
-CelExpression & CelExpression::operator = (CelExpression &expression){
+CelExpression & CelExpression::operator = (const CelExpression &expression){
     this->node_type = CelExpression::NODE_PROXY;
-    this->left = &expression;
+    this->left = const_cast<CelExpression*>(&expression);
     this->right = NULL;
 
     return *this;

--- a/Rehearse/src/CelExpression.h
+++ b/Rehearse/src/CelExpression.h
@@ -82,7 +82,7 @@ public:
     friend CelExpression & operator - (CelExpression &expression);
 
     CelExpression & operator += (CelExpression &expression);
-    CelExpression & operator = (CelExpression &expression);
+    CelExpression & operator = (const CelExpression &expression);
 
     void display() const;
     void display(int indent) const;

--- a/Rehearse/src/CelNumVar.cpp
+++ b/Rehearse/src/CelNumVar.cpp
@@ -44,12 +44,6 @@ CelNumVar::CelNumVar() : CelVariable("", -COIN_DBL_MAX, COIN_DBL_MAX) {
     initMe();
 }
 
-CelNumVar& CelNumVar::operator= (const CelNumVar other){
-    *this = other;
-    return *this;
-}
-
-
 CelNumVar::~CelNumVar(){
 }
 

--- a/Rehearse/src/CelNumVar.h
+++ b/Rehearse/src/CelNumVar.h
@@ -14,7 +14,6 @@ public:
     CelNumVar(const char *namestr);
     CelNumVar(std::string &name, double lower_bound, double upper_bound);
     CelNumVar(const char *namestr, double lower_bound, double upper_bound);
-    CelNumVar& operator= (const CelNumVar other);
 
     ~CelNumVar();
 


### PR DESCRIPTION
CelBoolVar and CelNumVar had incorrect implementationsfor their assignment operators.

For example compiling with clang 3.9 and -Winfinite-recursion turned on you get:
```
CelNumVar.cpp:47:56: warning: all paths through this function will call itself [-Winfinite-recursion]
CelNumVar& CelNumVar::operator= (const CelNumVar other){
...
CelBoolVar.cpp:17:59: warning: all paths through this function will call itself [-Winfinite-recursion]
CelBoolVar& CelBoolVar::operator= (const CelBoolVar other){
```

This PR drops the broken assignment operators. As they lead to infinite recursion we can be sure they were never actually called anywhere. However they still are instantiated in the tests so we have to change the CelExpression definition to accept a const argument to make things compile again. While the tests still run I can't say I'm comfortable with casting away the constness there but as I don't know Rehearse very well it was the most minimal change I could make to get it to build and test. The way the inheritance structure handles operators and copying looks like it would be worth reviewing as it feels like it could enable you to produce some unexpected results.

