### PR TITLE
Change `download_dependencies.sh` to only depend on `sh`

### DIFF
--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 svn co https://projects.coin-or.org/svn/BuildTools/stable/0.8/ BuildTools
 svn co https://projects.coin-or.org/svn/Cbc/stable/2.9/Cbc Cbc


### PR DESCRIPTION
As written, the script `download_dependencies.sh` requires `bash` to run, even though it doesn't require `bash`-specific commands. Changing this to `sh` does not alter the script, and allows users that don't have `bash` installed run the script without editing.

Use case: `bash` is not installed by default on Alpine Linux for Docker.